### PR TITLE
Task/pow operating on bytes

### DIFF
--- a/blockchain/block/block.go
+++ b/blockchain/block/block.go
@@ -17,12 +17,9 @@ func (b *Block) String() string {
 }
 
 // Creates a new block, creates the merkletree and creates a valid PoW.
-func NewBlock(prevblock *Block, timestamp time.Time, body *Body) *Block {
-	header := &Header{
-		Height:    prevblock.Header.Height + 1,
-		PrevHash:  prevblock.Header.Hash,
-		Timestamp: timestamp,
-	}
+func NewBlock(prevBlock *Block, timestamp time.Time, body *Body) *Block {
+	prevHeader := prevBlock.Header
+	header := NewHeader(prevHeader.Hash, prevHeader.Height+1, timestamp)
 
 	// TODO make this less implicit to implementing methods.
 	header.MerkleRoot = body.CalculateMerkle().MerkleRoot()
@@ -36,11 +33,7 @@ func NewBlock(prevblock *Block, timestamp time.Time, body *Body) *Block {
 
 // Creates a new genesis block, which doesn't have a previous block.
 func NewGenesisBlock(timestamp time.Time, body *Body) *Block {
-	header := &Header{
-		Height:    0,
-		PrevHash:  []byte{},
-		Timestamp: timestamp,
-	}
+	header := NewHeader([]byte{}, 0, timestamp)
 
 	// TODO make this less implicit to implementing methods.
 	header.MerkleRoot = body.CalculateMerkle().MerkleRoot()

--- a/blockchain/block/header.go
+++ b/blockchain/block/header.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Header struct {
-	Height     uint32    `json:"height"`
+	Height     uint64    `json:"height"`
 	Hash       c.Hash    `json:"hash"`
 	PrevHash   c.Hash    `json:"prevhash"`
 	Timestamp  time.Time `json:"timestamp"`
@@ -39,4 +39,12 @@ func (h Header) CalculateHash() (c.Hash, error) {
 
 	md := hash.Sum(nil)
 	return md, nil
+}
+
+func NewHeader(prevHash c.Hash, height uint64, timestamp time.Time) *Header {
+	return &Header{
+		Height:    height,
+		PrevHash:  prevHash,
+		Timestamp: timestamp,
+	}
 }

--- a/blockchain/block/pow.go
+++ b/blockchain/block/pow.go
@@ -6,6 +6,9 @@ import (
 	c "github.com/fluxchain/core/crypto"
 )
 
+// This is viacoin's minimum difficulty.
+var MINIMAL_POW = [32]byte{0x00, 0x00, 0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+
 // Generates a proof-of-work by simply generating a blockhash and checking if
 // the first 4 characters are all zeroes. Need to rework this.
 func (h *Header) GeneratePOW() []byte {
@@ -18,9 +21,7 @@ func (h *Header) GeneratePOW() []byte {
 			panic(err)
 		}
 
-		hashStr := hash.String()
-
-		if hashStr[:4] == "0000" {
+		if result := bytes.Compare(hash, MINIMAL_POW[:]); result <= 0 {
 			break
 		}
 


### PR DESCRIPTION
Refactored the header creation a bit, made POW compare by bytes rather than casting it to a string. This way I can later-on have difficulty adjustment operate in a more granular fashion.